### PR TITLE
complex filters to enable/disable benches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.76.0  # MSRV
-          - 1.81.0  # MSRV
+          - 1.85.0  # MSRV
     name: test-${{ matrix.features.label}}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,3 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           rust-toolchain: ${{ env.rust_stable }}
-          release-type: minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ Supports field-based targeting:
 - bench_name (alias: b)
 
 Enables granular selections, e.g., cargo bench -- "bench_name:my_bench AND group_name:my_group".
+You can also use the `BINGGAN_FILTER` environment variable to apply a filter.
 Keeps backward compatibility: basic strings fallback to substring matches on the full bench ID.
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased (2026-04-08)
 ### Features
 - Advanced filtering engine via `tantivy-query-grammar`
 ```
-Replaced basic substring filtering with a powerful querying engine using tantivy-query-grammar.
+Extended basic substring filtering with a powerful querying engine using tantivy-query-grammar.
 
 Supports logical operators: AND, OR, NOT (and their symbols like -).
 Supports field-based targeting:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+Unreleased (2026-04-08)
+==================
+### Features
+- Advanced filtering engine via `tantivy-query-grammar`
+```
+Replaced basic substring filtering with a powerful querying engine using tantivy-query-grammar.
+
+Supports logical operators: AND, OR, NOT (and their symbols like -).
+Supports field-based targeting:
+- runner_name (alias: r)
+- group_name (alias: g)
+- bench_name (alias: b)
+
+Enables granular selections, e.g., cargo bench -- "bench_name:my_bench AND group_name:my_group".
+Keeps backward compatibility: basic strings fallback to substring matches on the full bench ID.
+```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "binggan"
 version = "0.15.3"
 authors = ["Pascal Seitz <pascal.seitz@gmail.com>"]
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/pseitz/binggan"
 repository = "https://github.com/pseitz/binggan"
 description = "Benchmarking library for stable Rust"
@@ -11,7 +11,7 @@ keywords = ["perf", "profiler", "benchmark", "memory"]
 categories = ["development-tools::profiling"]
 license = "MIT"
 exclude = ["*logo*"]
-rust-version = "1.76"
+rust-version = "1.85"
 
 [lints.clippy]
 cargo        = { priority = -1, level = "deny" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rustop = "=1.1.4"
 rustc-hash = "2.0.0"
 bpu_trasher = { version = "0.2.0", optional = true }
 quanta = "0.12"
+tantivy-query-grammar = "0.26.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 perf-event = { version = "0.4.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binggan"
-version = "0.15.3"
+version = "0.16.0"
 authors = ["Pascal Seitz <pascal.seitz@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/pseitz/binggan"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ While number of allocations are also interesting for performance analysis, peak 
 Binggan has a filtering system built in, powered by `tantivy-query-grammar`. You can run a subset of benchmarks by providing a query string to the CLI:
 
 ```bash
+cargo bench -- "my_group"
 cargo bench -- "bench_name:my_bench AND group_name:my_group"
 cargo bench -- "my_bench OR other_bench"
 cargo bench -- "NOT other_bench"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It is designed to be simple to use and to provide a good overview of the perform
 * 📈 Custom Reporter
 * 🧩 Report Output of Benchmarks
 * 🎨 NOW with colored output!
+* 🔍 Advanced Filtering (AND/OR/NOT and fields like `bench_name:my_bench`)
 
 ### Example
 
@@ -98,6 +99,19 @@ FxHashMap              Memory: 28.3 MB      Avg: 403.52 MiB/s (+0.00%)    Median
 To activate peak memory reporting, you need to wrap your allocator with the PeakMemAlloc and enable the PeakMemAllocPlugin (see example above).
 
 While number of allocations are also interesting for performance analysis, peak memory will determine the memory requirements of the code.
+
+### Filtering
+
+Binggan has a powerful filtering system built in, powered by `tantivy-query-grammar`. You can run a subset of benchmarks by providing a query string to the CLI:
+
+```bash
+cargo bench -- "bench_name:my_bench AND group_name:my_group"
+cargo bench -- "my_bench OR other_bench"
+cargo bench -- "NOT other_bench"
+cargo bench -- "r:my_runner b:my_bench -g:my_group"
+```
+
+Available fields are `runner_name` (or `r`), `group_name` (or `g`), and `bench_name` (or `b`). If no field is specified, it will match against the full generated `BenchId`.
 
 ### Perf Integration
 Perf may run into limitations where all counters are reported as zero. https://github.com/jimblandy/perf-event/issues/2

--- a/README.md
+++ b/README.md
@@ -85,14 +85,17 @@ cargo bench
 
 turbo_buckets_vs_fxhashmap_full_unique
 100k max id / 100k num elem
-TurboBuckets           Memory: 786.4 KB     Avg: 2.1107 GiB/s (+0.19%)    Median: 2.1288 GiB/s (+0.69%)    [1.9055 GiB/s .. 2.1464 GiB/s]    
-FxHashMap              Memory: 1.8 MB       Avg: 1.1116 GiB/s (-0.65%)    Median: 1.1179 GiB/s (-0.90%)    [1020.2 MiB/s .. 1.1363 GiB/s]    
+TurboBuckets         Memory: 786.4 KB     Avg: 1.6356 GB/s (+0.18%)    Median: 1.6397 GB/s (+0.83%)    [1.5530 GB/s .. 1.6740 GB/s]    Output: 100_000    
+FlushVec             Memory: 200.0 KB     Avg: 8.7891 GB/s (-1.16%)    Median: 8.8631 GB/s (-0.40%)    [8.0207 GB/s .. 8.9986 GB/s]    Output: 100_000    
+FlushVec With Val    Memory: 3.2 MB       Avg: 3.7802 GB/s (-0.31%)    Median: 3.7875 GB/s (-0.00%)    [3.5477 GB/s .. 3.9165 GB/s]    Output: 100_000    
+TurboFlexBuckets     Memory: 786.5 KB     Avg: 1.2632 GB/s (+0.28%)    Median: 1.2653 GB/s (+0.40%)    [1.2282 GB/s .. 1.2810 GB/s]    Output: 100_000    
+Vec with Val         Memory: 3.2 MB       Avg: 1.2488 GB/s (-1.16%)    Median: 1.2526 GB/s (-0.97%)    [1.1634 GB/s .. 1.3042 GB/s]    Output: 100_001    
 500k max id / 500k num elem
-TurboBuckets           Memory: 2.4 MB       Avg: 5.7073 GiB/s (-0.29%)    Median: 5.7633 GiB/s (-0.55%)    [5.1313 GiB/s .. 6.1104 GiB/s]    
-FxHashMap              Memory: 14.2 MB      Avg: 521.50 MiB/s (-1.81%)    Median: 523.42 MiB/s (-1.75%)    [465.28 MiB/s .. 562.83 MiB/s]    
-1m max id / 1m num elem
-TurboBuckets           Memory: 4.5 MB       Avg: 6.2922 GiB/s (+5.48%)    Median: 6.3850 GiB/s (+6.56%)    [4.9580 GiB/s .. 6.7989 GiB/s]    
-FxHashMap              Memory: 28.3 MB      Avg: 403.52 MiB/s (+0.00%)    Median: 396.74 MiB/s (+0.97%)    [355.83 MiB/s .. 473.37 MiB/s]    
+TurboBuckets         Memory: 2.4 MB        Avg: 4.1036 GB/s (+0.48%)    Median: 4.0994 GB/s (-0.02%)    [3.9879 GB/s .. 4.2272 GB/s]    Output: 500_000    
+FlushVec             Memory: 1000.0 KB     Avg: 8.8669 GB/s (+1.50%)    Median: 8.8787 GB/s (+0.67%)    [8.6667 GB/s .. 8.9674 GB/s]    Output: 500_000    
+FlushVec With Val    Memory: 16.0 MB       Avg: 1.8976 GB/s (-1.03%)    Median: 1.9574 GB/s (+1.46%)    [1.1587 GB/s .. 2.0764 GB/s]    Output: 500_000    
+TurboFlexBuckets     Memory: 2.4 MB        Avg: 2.1348 GB/s (+0.72%)    Median: 2.1412 GB/s (+0.55%)    [2.0800 GB/s .. 2.1732 GB/s]    Output: 500_000    
+Vec with Val         Memory: 16.0 MB       Avg: 4.3664 GB/s (-2.64%)    Median: 4.5571 GB/s (+0.19%)    [2.1844 GB/s .. 4.8527 GB/s]    Output: 500_001    
 ```
 
 ### Peak Memory
@@ -102,7 +105,7 @@ While number of allocations are also interesting for performance analysis, peak 
 
 ### Filtering
 
-Binggan has a powerful filtering system built in, powered by `tantivy-query-grammar`. You can run a subset of benchmarks by providing a query string to the CLI:
+Binggan has a filtering system built in, powered by `tantivy-query-grammar`. You can run a subset of benchmarks by providing a query string to the CLI:
 
 ```bash
 cargo bench -- "bench_name:my_bench AND group_name:my_group"

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ cargo bench -- "NOT other_bench"
 cargo bench -- "r:my_runner b:my_bench -g:my_group"
 ```
 
+You can also use the `BINGGAN_FILTER` environment variable to set the filter:
+
+```bash
+BINGGAN_FILTER="my_bench OR other_bench" cargo bench
+```
+
 Available fields are `runner_name` (or `r`), `group_name` (or `g`), and `bench_name` (or `b`). If no field is specified, it will match against the full generated `BenchId`.
 
 ### Perf Integration

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,4 @@
-use binggan::{black_box, plugins::*, BenchRunner, PeakMemAlloc, INSTRUMENTED_SYSTEM};
+use binggan::{BenchRunner, INSTRUMENTED_SYSTEM, PeakMemAlloc, black_box, plugins::*};
 
 #[global_allocator]
 pub static GLOBAL: &PeakMemAlloc<std::alloc::System> = &INSTRUMENTED_SYSTEM;

--- a/benches/bench_group.rs
+++ b/benches/bench_group.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use binggan::{black_box, plugins::*, BenchRunner, PeakMemAlloc, INSTRUMENTED_SYSTEM};
+use binggan::{BenchRunner, INSTRUMENTED_SYSTEM, PeakMemAlloc, black_box, plugins::*};
 
 #[global_allocator]
 pub static GLOBAL: &PeakMemAlloc<std::alloc::System> = &INSTRUMENTED_SYSTEM;

--- a/benches/bench_input.rs
+++ b/benches/bench_input.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use binggan::{black_box, plugins::*, InputGroup, PeakMemAlloc, INSTRUMENTED_SYSTEM};
+use binggan::{INSTRUMENTED_SYSTEM, InputGroup, PeakMemAlloc, black_box, plugins::*};
 
 #[global_allocator]
 pub static GLOBAL: &PeakMemAlloc<std::alloc::System> = &INSTRUMENTED_SYSTEM;

--- a/benches/test_bench.rs
+++ b/benches/test_bench.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, time::Duration};
 
 use binggan::{
+    BenchRunner, INSTRUMENTED_SYSTEM, PeakMemAlloc,
     plugins::{CacheTrasher, PeakMemAllocPlugin, PerfCounterPlugin},
-    BenchRunner, PeakMemAlloc, INSTRUMENTED_SYSTEM,
 };
 use quanta::Instant;
 

--- a/src/bench_group.rs
+++ b/src/bench_group.rs
@@ -99,7 +99,11 @@ impl<'a, 'runner> BenchGroup<'a, 'runner> {
         input: &'a I,
     ) {
         self.output_value_column_title = O::column_title();
-        if let Some(filter) = &self.runner.config.filter {
+        if let Some(filter_ast) = &self.runner.filter_ast {
+            if !crate::filter::matches_filter(filter_ast, &bench.bench_id) {
+                return;
+            }
+        } else if let Some(filter) = &self.runner.config.filter {
             let bench_id = bench.bench_id.get_full_name();
 
             if !bench_id.contains(filter) {

--- a/src/bench_input_group.rs
+++ b/src/bench_input_group.rs
@@ -161,5 +161,5 @@ impl<I: 'static, O: OutputValue + 'static> InputGroup<I, O> {
 }
 
 unsafe fn transmute_lifetime<I>(input: &I) -> &'static I {
-    mem::transmute(input)
+    unsafe { mem::transmute(input) }
 }

--- a/src/bench_input_group.rs
+++ b/src/bench_input_group.rs
@@ -3,7 +3,7 @@ use std::mem;
 use crate::output_value::OutputValue;
 use crate::plugins::{EventListener, PluginManager};
 use crate::{
-    bench::NamedBench, bench_id::BenchId, bench_runner::BenchRunner, parse_args, BenchGroup, Config,
+    BenchGroup, Config, bench::NamedBench, bench_id::BenchId, bench_runner::BenchRunner, parse_args,
 };
 
 /// `InputGroup<Input, OutputValue>` is a collection of benchmarks that are run with the same inputs.

--- a/src/bench_runner.rs
+++ b/src/bench_runner.rs
@@ -16,6 +16,7 @@ use crate::{
 ///
 pub struct BenchRunner {
     pub(crate) config: Config,
+    pub(crate) filter_ast: Option<tantivy_query_grammar::UserInputAst>,
     /// The size of the input.
     /// Enables throughput reporting.
     input_size_in_bytes: Option<usize>,
@@ -66,8 +67,14 @@ impl BenchRunner {
         let mut plugins = PluginManager::new();
         plugins.add_plugin_if_absent(PlainReporter::new());
 
+        let filter_ast = options
+            .filter
+            .as_deref()
+            .and_then(|f| tantivy_query_grammar::parse_query(f).ok());
+
         BenchRunner {
             config: options,
+            filter_ast,
             input_size_in_bytes: None,
             name: None,
             plugins,

--- a/src/bench_runner.rs
+++ b/src/bench_runner.rs
@@ -5,11 +5,11 @@ use crate::output_value::OutputValue;
 use crate::plugins::{EventListener, PluginEvents, PluginManager};
 use crate::report::PlainReporter;
 use crate::{
+    BenchGroup, Config,
     bench::{Bench, InputWithBenchmark, NamedBench},
     bench_id::BenchId,
     black_box, parse_args,
     report::report_group,
-    BenchGroup, Config,
 };
 
 /// The main struct to run benchmarks.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub interleave: bool,
     /// The filter for the benchmarks
     /// This is read from the command line by default.
+    /// Supports tantivy query grammar like `bench_name:my_bench AND group_name:my_group`
     pub filter: Option<String>,
     /// Verbose output of binggan. Prints the number of iterations.
     pub verbose: bool,
@@ -107,7 +108,7 @@ pub(crate) fn parse_args() -> Config {
                          This may lead to better results, it may also lead to worse results.
                          It very much depends on the benches and the environment you would like to simulate. ";
         opt exact:bool, desc:"Filter benchmarks by exact name rather than by pattern.";
-        param filter:Option<String>, desc:"run only bench containing name."; // an optional positional parameter
+        param filter:Option<String>, desc:"run only bench matching filter. Supports AND/OR and fields like runner_name, group_name, bench_name."; // an optional positional parameter
     }
     .parse();
     if let Ok((args, _rest)) = res {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,9 +28,10 @@ impl Default for Config {
     fn default() -> Self {
         // Check ENV for verbose
         let verbose = std::env::var("BINGGAN_VERBOSE").is_ok();
+        let filter = std::env::var("BINGGAN_FILTER").ok();
         Config {
             interleave: true,
-            filter: None,
+            filter,
             verbose,
             num_iter_bench: None,
             num_iter_group: None,
@@ -112,10 +113,11 @@ pub(crate) fn parse_args() -> Config {
     }
     .parse();
     if let Ok((args, _rest)) = res {
+        let default_config = Config::default();
         Config {
             interleave: args.interleave,
-            filter: args.filter,
-            ..Default::default()
+            filter: args.filter.or(default_config.filter),
+            ..default_config
         }
     } else if let Err(rustop::Error::Help(help)) = res {
         println!("{}", help);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,120 @@
+use crate::bench_id::BenchId;
+use tantivy_query_grammar::{Occur, UserInputAst, UserInputLeaf};
+
+pub(crate) fn matches_filter(ast: &UserInputAst, bench_id: &BenchId) -> bool {
+    match ast {
+        UserInputAst::Clause(clauses) => {
+            // A clause is a list of sub-ASTs with their Occur (Must, MustNot, Should)
+            // By default, if there are Must clauses, all of them must match.
+            // If there are only Should clauses, at least one must match.
+            // MustNot clauses must not match.
+
+            let mut has_must = false;
+            let mut must_matches = true;
+
+            let mut has_should = false;
+            let mut should_matches = false;
+
+            for (occur, sub_ast) in clauses {
+                let m = matches_filter(sub_ast, bench_id);
+                match occur {
+                    Some(Occur::Must) => {
+                        has_must = true;
+                        if !m {
+                            must_matches = false;
+                        }
+                    }
+                    Some(Occur::MustNot) => {
+                        if m {
+                            return false; // Fast fail
+                        }
+                    }
+                    Some(Occur::Should) | None => {
+                        has_should = true;
+                        if m {
+                            should_matches = true;
+                        }
+                    }
+                }
+            }
+
+            if has_must {
+                must_matches
+            } else if has_should {
+                should_matches
+            } else {
+                true
+            }
+        }
+        UserInputAst::Leaf(leaf) => {
+            match &**leaf {
+                UserInputLeaf::Literal(lit) => {
+                    let field = lit.field_name.as_deref();
+                    let phrase = &lit.phrase;
+                    match field {
+                        Some("r") | Some("runner_name") => bench_id
+                            .runner_name
+                            .as_deref()
+                            .unwrap_or_default()
+                            .contains(phrase),
+                        Some("g") | Some("group_name") => bench_id
+                            .group_name
+                            .as_deref()
+                            .unwrap_or_default()
+                            .contains(phrase),
+                        Some("b") | Some("bench_name") => bench_id.bench_name.contains(phrase),
+                        _ => bench_id.get_full_name().contains(phrase),
+                    }
+                }
+                UserInputLeaf::All => true,
+                _ => false, // We only support Literals and All for now (no Regex, Range, etc)
+            }
+        }
+        _ => false, // Boost etc. ignored
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter() {
+        let bench_id = BenchId::from_bench_name("my_bench")
+            .runner_name(Some("my_runner"))
+            .group_name(Some("my_group".to_string()));
+
+        let queries = [
+            ("my_bench", true),
+            ("my_runner", true),
+            ("my_group", true),
+            ("my_bench AND my_runner", true),
+            ("my_bench AND other_runner", false),
+            ("my_bench OR other_runner", true),
+            ("other_bench OR other_runner", false),
+            ("bench_name:my_bench", true),
+            ("bench_name:other_bench", false),
+            ("group_name:my_group AND bench_name:my_bench", true),
+            ("group_name:my_group bench_name:my_bench", true), // When no operator is specified, terms default to SHOULD. Both match here.
+            ("group_name:my_group bench_name:other_bench", true), // With SHOULD terms, only one needs to match.
+            ("my_bench NOT other_runner", true),
+            ("my_bench -other_runner", true),
+            ("my_bench NOT my_runner", false),
+            ("my_bench -my_runner", false),
+            ("NOT other_runner", true),
+            ("-other_runner", true),
+            ("NOT my_runner", false),
+            ("-my_runner", false),
+        ];
+
+        for (query_str, expected) in queries {
+            let ast = tantivy_query_grammar::parse_query(query_str).unwrap();
+            assert_eq!(
+                matches_filter(&ast, &bench_id),
+                expected,
+                "query: {}",
+                query_str
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@ pub mod report;
 pub(crate) mod bench;
 pub(crate) mod bench_id;
 pub(crate) mod bench_runner;
+pub(crate) mod filter;
 pub(crate) mod output_value;
 pub(crate) mod stats;
 pub(crate) mod write_results;

--- a/src/plugins/perf_counter/linux.rs
+++ b/src/plugins/perf_counter/linux.rs
@@ -4,13 +4,13 @@ use std::io;
 
 use crate::bench_id::BenchId;
 use crate::plugins::{EventListener, PerBenchData, PluginEvents};
-use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, Software, WhichCache};
 use perf_event::Counter;
+use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, Software, WhichCache};
 use perf_event::{Builder, Group};
 use std::any::Any;
 use yansi::Paint;
 
-use super::{default_perf_counters, PerfCounter, PerfCounterValues, PERF_CNT_EVENT_LISTENER_NAME};
+use super::{PERF_CNT_EVENT_LISTENER_NAME, PerfCounter, PerfCounterValues, default_perf_counters};
 
 impl PerfCounter {
     /// Maps each enum variant to the appropriate `Hardware` or `Cache` type

--- a/src/report/plain_reporter.rs
+++ b/src/report/plain_reporter.rs
@@ -42,15 +42,11 @@ impl EventListener for PlainReporter {
                 }
                 println!("{}", group_name.black().on_yellow().invert().bold());
             }
-            PluginEvents::GroupBenchNumIters { num_iter } => {
-                if self.print_num_iter {
-                    println!("Num Iter Benches in Group {}", num_iter.bold());
-                }
+            PluginEvents::GroupBenchNumIters { num_iter } if self.print_num_iter => {
+                println!("Num Iter Benches in Group {}", num_iter.bold());
             }
-            PluginEvents::GroupNumIters { num_iter } => {
-                if self.print_num_iter {
-                    println!("Num Iter Group {}", num_iter.bold());
-                }
+            PluginEvents::GroupNumIters { num_iter } if self.print_num_iter => {
+                println!("Num Iter Group {}", num_iter.bold());
             }
             PluginEvents::GroupStop {
                 runner_name: _,

--- a/src/report/plain_reporter.rs
+++ b/src/report/plain_reporter.rs
@@ -2,10 +2,10 @@ use std::any::Any;
 
 use yansi::Paint;
 
-use super::{avg_median_str, memory_str, min_max_str, BenchStats, REPORTER_PLUGIN_NAME};
+use super::{BenchStats, REPORTER_PLUGIN_NAME, avg_median_str, memory_str, min_max_str};
 use crate::{
     plugins::{EventListener, PluginEvents},
-    report::{check_and_print, PrintOnce},
+    report::{PrintOnce, check_and_print},
 };
 
 /// The PlainReporter prints the results in a plain text table.

--- a/src/report/table_reporter.rs
+++ b/src/report/table_reporter.rs
@@ -2,10 +2,10 @@ use std::any::Any;
 
 use yansi::Paint;
 
-use super::{avg_median_str, memory_str, min_max_str, REPORTER_PLUGIN_NAME};
+use super::{REPORTER_PLUGIN_NAME, avg_median_str, memory_str, min_max_str};
 use crate::{
     plugins::{EventListener, PluginEvents},
-    report::{check_and_print, PrintOnce},
+    report::{PrintOnce, check_and_print},
 };
 
 /// The TableReporter prints the results using prettytable.


### PR DESCRIPTION

- Advanced filtering engine via `tantivy-query-grammar`
```
Extended basic substring filtering with a powerful querying engine using tantivy-query-grammar.

Supports logical operators: AND, OR, NOT (and their symbols like -).
Supports field-based targeting:
- runner_name (alias: r)
- group_name (alias: g)
- bench_name (alias: b)

Enables granular selections, e.g., cargo bench -- "bench_name:my_bench AND group_name:my_group".
You can also use the `BINGGAN_FILTER` environment variable to apply a filter.
Keeps backward compatibility: basic strings fallback to substring matches on the full bench ID.