### PR TITLE
Compare output values across benchmark runs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binggan"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Pascal Seitz <pascal.seitz@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/pseitz/binggan"

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -6,6 +6,7 @@ use crate::{
     output_value::OutputValue,
     plugins::{alloc::*, *},
     stats::*,
+    write_results::fetch_previous_run,
 };
 use quanta::Clock;
 
@@ -48,7 +49,7 @@ impl<'a, I, O: OutputValue> NamedBench<'a, I, O> {
 }
 
 /// The result of a single benchmark.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BenchResult {
     /// The bench id uniquely identifies the benchmark.
     /// It is a combination of the group name, input name and benchmark name.
@@ -63,8 +64,11 @@ pub struct BenchResult {
     pub old_perf_counter: Option<PerfCounterValues>,
     /// The size of the input in bytes if available.
     pub input_size_in_bytes: Option<usize>,
-    /// The size of the output returned by the bench. Enables reporting.
+    /// The formatted output returned by the bench. Enables reporting.
     pub output_value: Option<String>,
+    /// The formatted delta between the current and previous output values, if available.
+    pub output_value_delta: Option<String>,
+    pub(crate) serialized_output_value: Option<String>,
     /// Memory tracking is enabled and the peak memory consumption is reported.
     pub tracked_memory: bool,
 }
@@ -130,7 +134,14 @@ impl<'a, I, O: OutputValue> Bench<'a> for InputWithBenchmark<'a, I, O> {
         let tracked_memory = memory_consumption.is_some();
 
         let perf_counter = get_perf_counter(plugins, &self.bench.bench_id, total_num_iter);
+        let previous_run = fetch_previous_run(&self.bench.bench_id);
         let output_value = (self.bench.fun)(self.input);
+        let output_value_delta = previous_run
+            .as_ref()
+            .and_then(|previous_run| previous_run.serialized_output_value.as_deref())
+            .and_then(O::deserialize)
+            .and_then(|old_output_value| output_value.format_delta(&old_output_value));
+        let serialized_output_value = output_value.serialize();
         BenchResult {
             bench_id: self.bench.bench_id.clone(),
             stats,
@@ -138,8 +149,10 @@ impl<'a, I, O: OutputValue> Bench<'a> for InputWithBenchmark<'a, I, O> {
             input_size_in_bytes: self.input_size_in_bytes,
             tracked_memory,
             output_value: output_value.format(),
-            old_stats: None,
-            old_perf_counter: None,
+            output_value_delta,
+            serialized_output_value,
+            old_stats: previous_run.as_ref().map(|previous_run| previous_run.stats),
+            old_perf_counter: previous_run.and_then(|previous_run| previous_run.perf_counter),
         }
     }
 

--- a/src/output_value.rs
+++ b/src/output_value.rs
@@ -12,8 +12,8 @@ use std::collections::HashMap;
 /// In a compression benchmark this could be the output size.
 /// In a tree this could be the number of nodes. Any metric that is interesting to compare.
 ///
-/// # Limitations
-/// OutputValue is currently not part of the delta detection between runs.
+/// Implementations can opt into storing and comparing output values across runs by overriding
+/// [OutputValue::serialize], [OutputValue::deserialize] and [OutputValue::format_delta].
 pub trait OutputValue {
     /// The formatted output value.
     /// If the value is None, it will not be printed.
@@ -22,6 +22,30 @@ pub trait OutputValue {
     /// The name of the column title. The default is "Output".
     fn column_title() -> &'static str {
         "Output"
+    }
+
+    /// Serialize the output value for comparison with the next run.
+    ///
+    /// Returning `None` keeps the old behavior: the formatted output is displayed, but no output
+    /// delta is stored or reported.
+    fn serialize(&self) -> Option<String> {
+        None
+    }
+
+    /// Deserialize a previously stored output value.
+    fn deserialize(_serialized: &str) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        None
+    }
+
+    /// Format the delta between this output value and another value.
+    fn format_delta(&self, _old: &Self) -> Option<String>
+    where
+        Self: Sized,
+    {
+        None
     }
 
     /// Whether the output should be buffered and dropped after the measurement was recorded.
@@ -35,6 +59,39 @@ pub trait OutputValue {
     }
 }
 
+fn serialize_json<T: miniserde::Serialize>(value: &T) -> Option<String> {
+    Some(miniserde::json::to_string(value))
+}
+
+fn deserialize_json<T: miniserde::Deserialize>(serialized: &str) -> Option<T> {
+    miniserde::json::from_str(serialized).ok()
+}
+
+fn format_percentage_delta(current: f64, old: f64) -> Option<String> {
+    if old == 0.0 || current == 0.0 || old == current || !old.is_finite() || !current.is_finite() {
+        return None;
+    }
+    let diff = (current / old - 1.0) * 100.0;
+    let diff_str = if diff >= 0.0 {
+        format!("(+{:.2}%)", diff)
+    } else {
+        format!("({:.2}%)", diff)
+    };
+    Some(diff_str)
+}
+
+fn format_u64_delta(current: u64, old: u64) -> Option<String> {
+    format_percentage_delta(current as f64, old as f64)
+}
+
+fn format_changed_delta<T: PartialEq>(current: &T, old: &T) -> Option<String> {
+    if current == old {
+        None
+    } else {
+        Some("(changed)".to_string())
+    }
+}
+
 impl OutputValue for () {
     fn format(&self) -> Option<String> {
         None
@@ -44,40 +101,138 @@ impl OutputValue for Option<u64> {
     fn format(&self) -> Option<String> {
         self.map(format_with_underscores)
     }
+
+    fn serialize(&self) -> Option<String> {
+        self.as_ref().and_then(serialize_json)
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        deserialize_json(serialized).map(Some)
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_u64_delta((*self)?, (*old)?)
+    }
 }
 impl OutputValue for u64 {
     fn format(&self) -> Option<String> {
         Some(format_with_underscores(*self))
+    }
+
+    fn serialize(&self) -> Option<String> {
+        serialize_json(self)
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        deserialize_json(serialized)
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_u64_delta(*self, *old)
     }
 }
 impl OutputValue for usize {
     fn format(&self) -> Option<String> {
         Some(format_with_underscores(*self as u64))
     }
+
+    fn serialize(&self) -> Option<String> {
+        serialize_json(&(*self as u64))
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        let value: u64 = deserialize_json(serialized)?;
+        value.try_into().ok()
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_u64_delta(*self as u64, *old as u64)
+    }
 }
 impl OutputValue for String {
     fn format(&self) -> Option<String> {
         Some(self.clone())
+    }
+
+    fn serialize(&self) -> Option<String> {
+        serialize_json(self)
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        deserialize_json(serialized)
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_changed_delta(self, old)
     }
 }
 impl OutputValue for f64 {
     fn format(&self) -> Option<String> {
         Some(self.to_string())
     }
+
+    fn serialize(&self) -> Option<String> {
+        serialize_json(self)
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        deserialize_json(serialized)
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_percentage_delta(*self, *old)
+    }
 }
 impl OutputValue for i64 {
     fn format(&self) -> Option<String> {
         Some(self.to_string())
+    }
+
+    fn serialize(&self) -> Option<String> {
+        serialize_json(self)
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        deserialize_json(serialized)
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_percentage_delta(*self as f64, *old as f64)
     }
 }
 impl OutputValue for bool {
     fn format(&self) -> Option<String> {
         Some(self.to_string())
     }
+
+    fn serialize(&self) -> Option<String> {
+        serialize_json(self)
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        deserialize_json(serialized)
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_changed_delta(self, old)
+    }
 }
 impl OutputValue for std::time::Duration {
     fn format(&self) -> Option<String> {
         Some(format_duration(self.as_nanos() as u64))
+    }
+
+    fn serialize(&self) -> Option<String> {
+        serialize_json(&(self.as_nanos() as u64))
+    }
+
+    fn deserialize(serialized: &str) -> Option<Self> {
+        let nanos: u64 = deserialize_json(serialized)?;
+        Some(Self::from_nanos(nanos))
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_u64_delta(self.as_nanos() as u64, old.as_nanos() as u64)
     }
 }
 impl OutputValue for std::time::Instant {
@@ -93,6 +248,10 @@ impl<T> OutputValue for Vec<T> {
     fn column_title() -> &'static str {
         "Vec(len)"
     }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_u64_delta(self.len() as u64, old.len() as u64)
+    }
 }
 impl<K, V> OutputValue for HashMap<K, V> {
     fn format(&self) -> Option<String> {
@@ -100,6 +259,10 @@ impl<K, V> OutputValue for HashMap<K, V> {
     }
     fn column_title() -> &'static str {
         "Map(len)"
+    }
+
+    fn format_delta(&self, old: &Self) -> Option<String> {
+        format_u64_delta(self.len() as u64, old.len() as u64)
     }
 }
 
@@ -121,6 +284,29 @@ mod tests {
     fn format_u64_test() {
         let value = 123456789u64;
         assert_eq!(value.format(), Some("123_456_789".to_string()));
+    }
+
+    #[test]
+    fn output_values_can_serialize_and_delta() {
+        let value = 150u64;
+        assert_eq!(value.serialize(), Some("150".to_string()));
+        assert_eq!(value.format_delta(&100), Some("(+50.00%)".to_string()));
+
+        let value = vec![1, 2, 3];
+        assert_eq!(value.serialize(), None);
+        assert_eq!(
+            value.format_delta(&vec![1, 2]),
+            Some("(+50.00%)".to_string())
+        );
+    }
+
+    #[test]
+    fn output_value_delta_for_changed_non_numeric_values() {
+        assert_eq!(
+            "new".to_string().format_delta(&"old".to_string()),
+            Some("(changed)".to_string())
+        );
+        assert_eq!(true.format_delta(&false), Some("(changed)".to_string()));
     }
 
     #[test]

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     bench::Bench,
     plugins::{PluginEvents, PluginManager},
     stats::compute_diff,
-    write_results::fetch_previous_run_and_write_results_to_disk,
+    write_results::write_results_to_disk,
 };
 
 /// The default reporter name. Choose this in `EventListener` to make sure there's only one
@@ -61,8 +61,8 @@ pub(crate) fn report_group<'a>(
 
     let mut results = Vec::new();
     for bench in benches.iter_mut() {
-        let mut result = bench.get_results(events);
-        fetch_previous_run_and_write_results_to_disk(&mut result);
+        let result = bench.get_results(events);
+        write_results_to_disk(&result);
         results.push(result);
     }
     events.emit(PluginEvents::GroupStop {

--- a/src/report/plain_reporter.rs
+++ b/src/report/plain_reporter.rs
@@ -2,8 +2,9 @@ use std::any::Any;
 
 use yansi::Paint;
 
-use super::{BenchStats, REPORTER_PLUGIN_NAME, avg_median_str, memory_str, min_max_str};
+use super::{REPORTER_PLUGIN_NAME, avg_median_str, memory_str, min_max_str};
 use crate::{
+    bench::BenchResult,
     plugins::{EventListener, PluginEvents},
     report::{PrintOnce, check_and_print},
 };
@@ -59,14 +60,7 @@ impl EventListener for PlainReporter {
                 for result in results {
                     let perf_counter = &result.perf_counter;
 
-                    let mut stats_columns = self.to_columns(
-                        result.stats,
-                        result.old_stats,
-                        result.input_size_in_bytes,
-                        &result.output_value,
-                        result.tracked_memory,
-                        output_value_column_title,
-                    );
+                    let mut stats_columns = self.to_columns(result, output_value_column_title);
                     stats_columns.insert(0, result.bench_id.bench_name.to_string());
                     table_data.push(stats_columns);
 
@@ -99,29 +93,33 @@ impl PlainReporter {
 
     pub(crate) fn to_columns(
         &self,
-        stats: BenchStats,
-        other: Option<BenchStats>,
-        input_size_in_bytes: Option<usize>,
-        output_value: &Option<String>,
-        report_memory: bool,
+        result: &BenchResult,
         output_value_column_title: &'static str,
     ) -> Vec<String> {
+        let stats = result.stats;
+        let other = result.old_stats;
+        let input_size_in_bytes = result.input_size_in_bytes;
         let (avg_str, median_str) = avg_median_str(&stats, input_size_in_bytes, other);
         let avg_str = format!("Avg: {}", avg_str);
         let median_str = format!("Median: {}", median_str);
 
         let min_max = min_max_str(&stats, input_size_in_bytes);
-        let memory_string = memory_str(&stats, other, report_memory);
-        if let Some(output_value) = output_value {
+        let memory_string = memory_str(&stats, other, result.tracked_memory);
+        if let Some(output_value) = &result.output_value {
             vec![
                 memory_string,
                 avg_str,
                 median_str,
                 min_max,
                 format!(
-                    "{}: {}",
+                    "{}: {}{}",
                     output_value_column_title,
-                    output_value.to_string()
+                    output_value,
+                    result
+                        .output_value_delta
+                        .as_deref()
+                        .map(|delta| format!(" {delta}"))
+                        .unwrap_or_default()
                 ),
             ]
         } else {

--- a/src/report/table_reporter.rs
+++ b/src/report/table_reporter.rs
@@ -104,9 +104,20 @@ impl EventListener for TableReporter {
                         Cell::new(&min_max),
                     ]);
                     if has_output_value {
-                        row.add_cell(Cell::new(
-                            result.output_value.as_ref().unwrap_or(&"".to_string()),
-                        ));
+                        let output_value = result
+                            .output_value
+                            .as_ref()
+                            .map(|value| {
+                                // Not every value can be formatted as delta
+                                let delta_formatted = result
+                                    .output_value_delta
+                                    .as_deref()
+                                    .map(|delta| format!(" {delta}"))
+                                    .unwrap_or_default();
+                                format!("{}{delta_formatted}", value,)
+                            })
+                            .unwrap_or_default();
+                        row.add_cell(Cell::new(&output_value));
                     }
                     if !result.tracked_memory {
                         row.remove_cell(1);

--- a/src/write_results.rs
+++ b/src/write_results.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf, sync::OnceLock};
 
-use crate::bench::BenchResult;
+use crate::{bench::BenchResult, bench_id::BenchId, plugins::PerfCounterValues, stats::BenchStats};
 
 /// Creates directory if it does not exist
 pub fn get_output_directory() -> &'static PathBuf {
@@ -20,31 +20,52 @@ pub fn get_output_directory() -> &'static PathBuf {
     })
 }
 
-fn get_bench_file(result: &BenchResult) -> PathBuf {
-    get_output_directory().join(result.bench_id.get_full_name())
+fn get_bench_file(bench_id: &BenchId) -> PathBuf {
+    get_output_directory().join(bench_id.get_full_name())
 }
 
-pub fn fetch_previous_run_and_write_results_to_disk(result: &mut BenchResult) {
+pub(crate) struct PreviousRun {
+    pub stats: BenchStats,
+    pub perf_counter: Option<PerfCounterValues>,
+    pub serialized_output_value: Option<String>,
+}
+
+pub(crate) fn fetch_previous_run(bench_id: &BenchId) -> Option<PreviousRun> {
     // Filepath in target directory
-    let filepath = get_bench_file(result);
+    let filepath = get_bench_file(bench_id);
     // Check if file exists and deserialize
     if filepath.exists() {
         let content = std::fs::read_to_string(&filepath).unwrap();
         let lines: Vec<_> = content.lines().collect();
-        result.old_stats = miniserde::json::from_str(lines[0]).unwrap();
-        result.old_perf_counter = lines
+        let stats = miniserde::json::from_str(lines[0]).unwrap();
+        let perf_counter = lines
             .get(1)
             .and_then(|line| miniserde::json::from_str(line).ok());
+        let serialized_output_value = lines.get(2).map(|line| (*line).to_string());
+        return Some(PreviousRun {
+            stats,
+            perf_counter,
+            serialized_output_value,
+        });
     }
+    None
+}
 
-    let perf_counter = &result.perf_counter;
-    let stats = &result.stats;
-    let filepath = get_bench_file(result);
-    let mut out = miniserde::json::to_string(&stats);
-    if let Some(perf_counter) = perf_counter {
+pub(crate) fn write_results_to_disk(result: &BenchResult) {
+    let mut out = miniserde::json::to_string(&result.stats);
+    if let Some(perf_counter) = &result.perf_counter {
         out.push('\n');
-        let perf_out = miniserde::json::to_string(&perf_counter);
+        let perf_out = miniserde::json::to_string(perf_counter);
         out.push_str(&perf_out);
     }
-    std::fs::write(filepath, out).unwrap();
+    if let Some(output_value) = &result.serialized_output_value {
+        if result.perf_counter.is_none() {
+            // Keep the second line reserved for perf counters so old readers still either read
+            // perf counters there or ignore the empty line.
+            out.push('\n');
+        }
+        out.push('\n');
+        out.push_str(output_value);
+    }
+    std::fs::write(get_bench_file(&result.bench_id), out).unwrap();
 }


### PR DESCRIPTION
Persist serializable output values with benchmark results and report
formatted deltas when previous values are available.
